### PR TITLE
Updated MKD.rmd

### DIFF
--- a/vignettes/iso/MKD.Rmd
+++ b/vignettes/iso/MKD.Rmd
@@ -1,8 +1,8 @@
 ---
-title: "Macedonia"
+title: "North Macedonia"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Macedonia}
+  %\VignetteIndexEntry{North Macedonia}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
@@ -42,7 +42,7 @@ src <- src %>% filter(data_type %in% colnames(x)) %>% distinct(title, .keep_all 
 src <- paste(sprintf("[%s](%s)", src$title, src$url), collapse = ", ")
 ```
 
-Data COVID-19 Macedonia: `tests` (cumulative number of tests), `confirmed` (cumulative number of confirmed cases), `deaths` (cumulative number of deaths), `recovered` (cumulative number of recovered), `hosp` (hospitalized on date), `vent` (requiring ventilation on date), `icu` (intensive therapy on date). See the [full dataset](/articles/data.html).
+Data COVID-19 North Macedonia: `tests` (cumulative number of tests), `confirmed` (cumulative number of confirmed cases), `deaths` (cumulative number of deaths), `recovered` (cumulative number of recovered), `hosp` (hospitalized on date), `vent` (requiring ventilation on date), `icu` (intensive therapy on date). See the [full dataset](/articles/data.html).
 
 ```{r, echo=FALSE}
 DT::datatable(x, rownames = FALSE, filter = 'top', options = list(


### PR DESCRIPTION
The country is officially called North Macedonia since February 12th, 2019.

# What type of PR is this?

Select all that apply: [ ] -> [x]

- [x] R 
- [ ] other

## R

I confirm: 

- [x] I followed the [tutorial](https://github.com/covid19datahub/COVID19/wiki/Add-a-new-data-source)
- [ ] I checked the format with the [`ds_check_format`](https://covid19datahub.io/reference/ds_check_format.html) function
- [x] I double checked the data (e.g. coherent with google search)

## Additional comments

Insert additional comments here...
